### PR TITLE
let `on_delete()` return `false` to skip deletion

### DIFF
--- a/indexpiration.lua
+++ b/indexpiration.lua
@@ -109,10 +109,13 @@ function F:start_worker()
 							end
 						end
 						if t then
+							local skip = false
 							if expiration.on_delete then
-								expiration.on_delete(t)
+								skip = false == expiration.on_delete(t)
 							end
-							space:delete( expiration._pk(t) )
+							if not skip then
+								space:delete( expiration._pk(t) )
+							end
 						end
 					end
 					if expiration.txn then


### PR DESCRIPTION
When the `on_delete()` function returns `false`, the library skips the deletion of the row.

Returning `true` (or `nil`) causes the row to be deleted as normal, so this change has no effect on existing code.

Note that when an row is not deleted, it will ordinarily retain its position in the index and be a candidate for deletion on the next pass. Therefore, user should be warned that if they return `false` from `on_delete()`, then they must either:
    a. modify the expiration field (to prolong the row from expiry),
    b. delete the row themselves, or
    a. expect another deletion attempt immediately.
